### PR TITLE
Enable Debug for Response

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ enum WorkInput {
     Exit,
 }
 
+#[derive(Debug)]
 pub struct Response {
     pub url: String,
     pub status: u16,


### PR DESCRIPTION
Helps with testing and debugging if you can just output `crabler::Response` objects directly through logging functions. Ends up looking like `Response { url: "<URL>", status: 200, download_destination: None, workinput_tx: Sender { .. }, counter: 1 }`