### PR TITLE
Update README example and add compile testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.23"
 authors = ["Max Gonzih <gonzih@gmail.com>"]
 edition = "2018"
 description = "Web scraper for Crabs"
+build = "build.rs"
 homepage = "https://github.com/Gonzih/crabler"
 repository = "https://github.com/Gonzih/crabler"
 documentation = "https://docs.rs/crabler"
@@ -29,4 +30,8 @@ crabler_derive = "0.1.7"
 crabquery = "0.1.8"
 # crabquery = { path = "/home/gnzh/mydev/crabquery" }
 
+[build-dependencies]
+skeptic = "0.13"
+
 [dev-dependencies]
+skeptic = "0.13"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+extern crate skeptic;
+
+fn main() {
+    // generates doc tests for `README.md`.
+    skeptic::generate_doc_tests(&["README.md"]);
+}

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));

--- a/tests/simple_roundtrip_tests.rs
+++ b/tests/simple_roundtrip_tests.rs
@@ -4,9 +4,6 @@ use crabler::*;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-#[macro_use]
-mod common;
-
 #[derive(WebScraper)]
 #[on_response(response_handler)]
 #[on_html("a[href]", print_handler)]


### PR DESCRIPTION
The existing README example doesn't compile. This fixes that and also adds compilation testing of the example.

I think it'd be more ideal to have this as a standalone example and to have a simpler example in the README (an example that downloads all images would be useful as well as a good example). But I couldn't figure out how to have the code just live in one place and work as an example and show up in the README in plain text.