### PR TITLE
Refactor to use built-in redirection middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ license = "MIT"
 debug = []
 
 [dependencies]
-async-recursion = "1.0.0"
 surf = "2.3.2"
 async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 futures = "0.3.18"


### PR DESCRIPTION
There was a bug in my previous redirection code, and switching to the built-in redirection handler fixes it. I think this makes more sense though it adds an extra HTTP request per fetch (to preserve the Body of the request).