### PR TITLE
Upgrade thiserror to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ surf = "2.3.2"
 async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 futures = "0.3.18"
 async-trait = "0.1.52"
-thiserror = "1.0"
+thiserror = "2"
 log = { version = "0.4.14", features = ["kv_unstable"] }
 femme = "2.1.1"
 crabler_derive = "0.1.8"


### PR DESCRIPTION
## Summary
- Updates `thiserror` dependency from `1.0` to `2` in `Cargo.toml`
- No source code changes required — existing error format strings are fully compatible with thiserror 2.0
- All 4 integration tests pass

Supersedes #17 (Dependabot PR for the same upgrade).

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — 4 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)